### PR TITLE
Fix issue with overlay div in Internet explorer 11

### DIFF
--- a/src/stylesheets/App.scss
+++ b/src/stylesheets/App.scss
@@ -57,6 +57,7 @@ body {
 main {
     width: $body-width;
     min-height: 50vh;
+    display: block;
     padding: 0 calc(50% - #{$half-body-width}) 3rem;
     font-family: $primary-font;
     flex: 1 0 auto;


### PR DESCRIPTION
This fix the issue with the white overlay div in Internet explorer  11.  The 'main' css class displays as a small square in the middle top left in IE.

**How to reproduce?**

Open the application in IE 10.

Best,